### PR TITLE
Avoid exceeding max stack

### DIFF
--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@
         handler(array[index], processNext, index);
       }
       else {
-        callback && callback();
+        callback && setImmediate(callback);
       }
     }
     processNext();

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -238,6 +238,14 @@ describe('factory', function() {
         done();
       });
     });
+
+    it("allows the creation of many objects", function(done) {
+      factory.createMany('job', 1000, function (err, jobs) {
+        if (err) return done(err);
+        jobs.length.should.eql(1000);
+        done();
+      });
+    });
   });
 
   describe('#cleanup', function() {


### PR DESCRIPTION
I used factory girl to easily generate a bunch of fixture data for a performance test, only to find that it could not create enough content.

This small fix allows an unlimited number of objects to be created.  The fix involved changing a utility method, so more things are likely affected, too.  Please let me know if you'd like me to update any other tests.

Thank you!