### PR TITLE
Added Bower.json Config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "factory-girl",
+  "main": "index.js",
+  "version": "1.0.2",
+  "homepage": "https://github.com/brandonkboswell/factory-girl",
+  "authors": [
+    "aexmachina"
+  ],
+  "keywords": [
+    "factory-girl",
+    "factory"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Any reason why these changes weren't submitted as a PR to my repo? I now have another user who's submitted a PR with AMD support and a bower.json file with the name factory-girl-amd. I'd like to unify all of this. Would you be open to pointing the factory-girl Bower package back at the aexmachina repo?