### PR TITLE
Add ability to provide default attributes for assoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ factory.define('user', User, {
 console.log(factory.build('user')); // => {state: 'active', email: 'user1@demo.com', async: 'foo'}
 
 factory.define('post', Post, {
-  // create associations using factory.assoc(model, attr)
-  // or factory.assoc('user') for user object itself
-  user_id: factory.assoc('user', 'id'),
+  // create associations using factory.assoc(model, key)
+  // or factory.assoc('user') to return the user object itself
+
+  // optionally provide default values to the associated
+  // factory by passing an object as third argument
+  user_id: factory.assoc('user', 'id', { role: author }),
   subject: 'Hello World',
   // you can refer to other attributes using `this`
   slug: function() {

--- a/index.js
+++ b/index.js
@@ -93,11 +93,12 @@
       return adapter.build(model, attrs);
     };
 
-    factory.assoc = function(name, attr) {
+    factory.assoc = function(name, key, attrs) {
+      attrs = attrs || {};
       return function(callback) {
-        factory.create(name, function(err, doc) {
+        factory.create(name, attrs, function(err, doc) {
           if (err) return callback(err);
-          callback(null, attr ? doc[attr] : doc);
+          callback(null, key ? doc[key] : doc);
         });
       };
     };

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -37,7 +37,7 @@ describe('factory', function() {
         return "email" + (emailCounter++) + "@noemail.com";
       },
       age: 25,
-      job: factory.assoc('job'),
+      job: factory.assoc('job', null, { company: 'Bazqux Co.' }),
       title: factory.assoc('job', 'title')
     });
 
@@ -78,7 +78,7 @@ describe('factory', function() {
             person.age.should.eql(30);
             (person.job instanceof Job).should.be.true;
             person.job.title.should.eql('Engineer');
-            person.job.company.should.eql('Foobar Inc.');
+            person.job.company.should.eql('Bazqux Co.');
             person.job.saveCalled.should.be.true;
             person.title.should.eql('Engineer');
             done();


### PR DESCRIPTION
This is a convenience for specializing associated models. It allows doing something similar to the example below, which would otherwise require the definition of an author factory:

````javascript
factory.define('post', Post, {
  user_id: factory.assoc('user', 'id', { role: 'author' })
  ...
});
````