### PR TITLE
Feature/after create take 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,14 +98,14 @@
           return callback(new Error("No factory defined for model '" + name + "'"));
         }
 
-        builder.build(name, attrs, function(err, doc, options) {
+        builder.build(name, attrs, function(err, doc) {
           if (err) return callback(err);
 
           save(name, doc, function(saveErr, saveDoc) {
             if(saveErr) return callback(saveErr);
 
             if (factories[name].options.afterCreate) {
-              factories[name].options.afterCreate.call(this, saveDoc, options, callback);
+              factories[name].options.afterCreate.call(this, saveDoc, builder.options, callback);
             } else {
               callback(saveErr, saveDoc);
             }
@@ -124,8 +124,6 @@
         }
         var model = factories[name].model;
         attrs = merge(copy(factories[name].attributes), attrs);
-
-        var options = builder.options;
 
         asyncForEach(keys(attrs), function(key, cb) {
           var fn = attrs[key];
@@ -149,7 +147,7 @@
           if (err) return callback(err);
           var adapter = factory.adapterFor(name),
               doc = adapter.build(model, attrs);
-          callback(null, doc, options);
+          callback(null, doc);
         });
       };
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "mocha": ">= 0.7.1",
-    "should": ">= 0.4.2"
+    "should": ">= 0.4.2",
+    "sinon": "^1.14.1"
   },
   "scripts": {
     "test": "mocha"

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -2,6 +2,7 @@
 var factory = require('..');
 var should = require('should');
 var context = describe;
+var sinon = require('sinon');
 
 describe('factory', function() {
   var Model, Person, Job;
@@ -143,6 +144,35 @@ describe('factory', function() {
           job.company.should.eql('Bazqux Co.');
           job.saveCalled.should.be.true;
           done();
+        });
+      });
+    });
+
+    context('defined with an afterCreate handler', function() {
+      var spy = sinon.spy();
+
+      before(function() {
+        factory.define('job with after create', Job, {
+          title: 'Engineer',
+          company: 'Foobar Inc.'
+        }, {
+          afterCreate: function(doc, options, done) {
+            spy.apply(null, arguments);
+            doc.title = 'Astronaut';
+            done(null, doc);
+          }
+        });
+      });
+
+      it('calls afterCreate', function() {
+        factory.create('job with after create', function(err, job) {
+          spy.called.should.be.true;
+        });
+      });
+
+      it('allows afterCreate to mutate the model', function() {
+        factory.create('job with after create', function(err, job) {
+          job.title.should.eql('Astronaut')
         });
       });
     });
@@ -328,6 +358,55 @@ describe('factory', function() {
       }).should.throw();
     });
 
+  });
+
+  describe('#withOptions', function() {
+    it('chains to expose the builder functions', function() {
+      var builder = factory.withOptions({ key: 'value' });
+
+      builder.should.have.property('build');
+      builder.should.have.property('buildSync');
+      builder.should.have.property('buildMany');
+      builder.should.have.property('create');
+      builder.should.have.property('createMany');
+
+      var job = builder.buildSync('job', { title: 'Mechanic' });
+      (job instanceof Job).should.be.true;
+      job.company.should.eql('Foobar Inc.');
+      job.title.should.eql('Mechanic');
+    });
+
+    it('passes options through to defined afterCreate handler', function() {
+      factory.define('job with after create', Job, {
+        title: 'Engineer',
+        company: 'Foobar Inc.'
+      }, {
+        afterCreate: function(doc, options, done) {
+          options.key.should.eql('value');
+          done(null, doc);
+        }
+      });
+
+      factory.withOptions({ key: 'value' }).create('job with after create', function() {});
+    });
+
+    it('allows for chaining to merge options', function() {
+      factory.define('job with after create', Job, {
+        title: 'Engineer',
+        company: 'Foobar Inc.'
+      }, {
+        afterCreate: function(doc, options, done) {
+          options.key.should.eql('value 2');
+          options.anotherKey.should.eql('value');
+          done(null, doc);
+        }
+      });
+
+      var builder = factory.withOptions({ key: 'value' });
+      builder.withOptions({ key: 'value 2', anotherKey: 'value' });
+
+      builder.create('job with after create', function() {});
+    });
   });
 
 });

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -248,7 +248,7 @@ describe('factory', function() {
             person.destroyCalled.should.be.true;
             person.job.destroyCalled.should.be.true;
             job.destroyCalled.should.be.true;
-            done(err);            
+            done(err);
           });
         });
       });


### PR DESCRIPTION
@aexmachina @kespindler Take 2 on the implementation of `afterCreate` and `options` based on discussion in #5 .. It's a rather sweeping change as I adapted all of the existing build/create/many functions into a builder pattern so we can do chaining. All existing tests pass, plus tests added for new functionality.

API is as discussed:

```js
factory.define('post', Post, {
  title: 'My post title',
}, {
  afterCreate: function(post, options, done) {
    // do something
    done(null, post);
  }
}
```

```js
factory.withOptions({ someOption: 'value' }).create(...);
factory.withOptions({ someOption: 'value' }).createMany(...);
```

Thoughts?