### PR TITLE
Replace merge with lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 (function(factory) {
 
+
   if (typeof exports !== 'undefined') {
     module.exports = factory();
     module.exports.ObjectAdapter = require('./lib/object-adapter');
@@ -332,17 +333,8 @@
     doc.destroy(cb);
   };
 
-  function merge(obj1, obj2) {
-    if (obj1 && obj2) {
-      var key;
-      for (key in obj2) {
-        if (obj2.hasOwnProperty(key)) {
-          obj1[key] = obj2[key];
-        }
-      }
-    }
-    return obj1;
-  }
+  var merge = require('lodash/object/merge');
+  
   function copy(obj) {
     var newObj = {};
     if (obj) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
       "url": "http://github.com/aexmachina/factory-girl/raw/master/LICENSE"
     }
   ],
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^3.10.0"
+  },
   "devDependencies": {
     "bluebird": "^2.9.25",
     "chai": "^3.0.0",

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -47,7 +47,12 @@ describe('factory', function() {
 
     factory.define('job', Job, {
       title: 'Engineer',
-      company: 'Foobar Inc.'
+      company: 'Foobar Inc.',
+      duties: {
+        cleaning: false,
+        writing: true,
+        computing: true
+      }
     });
 
     factory.define('company', Company, {
@@ -69,11 +74,14 @@ describe('factory', function() {
 
       context('passing attributes as second argument', function() {
         it('sets them', function(done) {
-          factory.build('job', { title: "Artist", company: "Bazqux Co." }, function(err, job) {
+          factory.build('job', { title: "Artist", company: "Bazqux Co.", duties: { cleaning: true, writing: false } }, function(err, job) {
             (job instanceof Job).should.be.true;
             job.title.should.eql('Artist');
             job.company.should.eql('Bazqux Co.');
             job.should.not.have.property('saveCalled');
+            job.duties.cleaning.should.be.true;
+            job.duties.writing.should.be.false;
+            job.duties.computing.should.be.true;
             done();
           });
         });
@@ -480,4 +488,3 @@ describe('factory', function() {
   });
 
 });
-


### PR DESCRIPTION
SOLVES:  Deep merging when overriding defaults.

USE CASE: Postgres json data types, or any other data store that supports json objects

When using FactoryGirl to create objects that supports json types, we found the existing merge to only handle top level merging.  

While we could make the existing code work by passing the entire json object as the override, this would be a bit annoying when the json object is very large (which is our case).  Ideally the defaults are always used and the exception would be to only override the parts you wish to change, rather than replace the entire object.  

If the intent is to replace the entire json object, it might make more sense to define a new factory with other defaults or you still could replace the entire object by passing the same structure with new values.