### PR TITLE
Support environments without requirejs

### DIFF
--- a/index.js
+++ b/index.js
@@ -353,7 +353,7 @@
     doc.destroy(cb);
   };
 
-  var merge = require('lodash.merge');
+  var merge = typeof require === 'function' ? require('lodash.merge') : _.merge;
   
   function copy(obj) {
     var newObj = {};


### PR DESCRIPTION
I've just finished implementing factory-girl in an Angular app for work - it's great! But since the app (and our tests) works in the browser, we don't use requirejs. I had to make a small change to enable factory-girl to work in our environment.

In environments without requirejs, it should instead reference _.merge, assuming lodash has been loaded for use in that environment.