### PR TITLE
Fix issue with setImmediate being undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -381,7 +381,7 @@
         handler(array[index], processNext, index);
       }
       else if (callback) {
-        setImmediate ? setImmediate(callback) : setTimeout(callback, 0);
+        typeof setImmediate === 'function' ? setImmediate(callback) : setTimeout(callback, 0);
       }
     }
     processNext();


### PR DESCRIPTION
This change makes it possible to use factory-girl in an environment where `setImmediate` is not available. When using factory-girl in a browser environment, referencing `setImmediate` on its own results in an exception being thrown.

By checking the type, we can avoid this problem.