### PR TITLE
Adds afterBuild to factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ var builder = factory.withOptions(options);
 
 Currently the supported options are:
 
+#### `afterBuild: function(instance, options, callback)`
+
+Provides a function that is called after the model is built.
+
 #### `afterCreate: function(instance, options, callback)`
 
 Provides a function that is called after a new model instance is saved.
@@ -208,5 +212,5 @@ It started out as a fork of [factory-lady](https://github.com/petejkim/factory-l
 
 ## License
 
-Copyright (c) 2014 Simon Wade. This software is licensed under the [MIT License](http://github.com/petejkim/factory-lady/raw/master/LICENSE).  
-Copyright (c) 2011 Peter Jihoon Kim. This software is licensed under the [MIT License](http://github.com/petejkim/factory-lady/raw/master/LICENSE).  
+Copyright (c) 2014 Simon Wade. This software is licensed under the [MIT License](http://github.com/petejkim/factory-lady/raw/master/LICENSE).
+Copyright (c) 2011 Peter Jihoon Kim. This software is licensed under the [MIT License](http://github.com/petejkim/factory-lady/raw/master/LICENSE).

--- a/index.js
+++ b/index.js
@@ -219,7 +219,13 @@
           if (err) return callback(err);
           var adapter = factory.adapterFor(name),
               doc = adapter.build(model, attrs);
-          callback(null, doc);
+
+          if (factories[name].options.afterBuild) {
+            factories[name].options.afterBuild.call(
+              this, doc, builder.options, callback);
+          } else {
+            callback(null, doc);
+          }
         });
       };
 
@@ -354,7 +360,7 @@
   };
 
   var merge = typeof require === 'function' ? require('lodash.merge') : _.merge;
-  
+
   function copy(obj) {
     var newObj = {};
     if (obj) {

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -102,6 +102,43 @@ describe('factory', function() {
         });
       });
 
+      context('defined with an afterBuild handler', function() {
+        var spy;
+
+        beforeEach(function() {
+          spy = sinon.spy();
+          factory.define('job with after build', Job, {
+            title: 'Engineer',
+            company: 'Foobar Inc.'
+          }, {
+            afterBuild: function(doc, options, done) {
+              spy.apply(null, arguments);
+              doc.title = 'Astronaut';
+              done(null, doc);
+            }
+          });
+        });
+
+        it('calls afterBuild', function() {
+          factory.build('job with after build', function(err, job) {
+            spy.called.should.be.true;
+          });
+        });
+
+        it('allows afterBuild to mutate the model', function() {
+          factory.build('job with after build', function(err, job) {
+            job.title.should.eql('Astronaut');
+          });
+        });
+
+        it('calls afterBuild with buildMany', function() {
+          var num = 10;
+          factory.buildMany('job with after build', num, function(err) {
+            spy.callCount.should.equal(num);
+          });
+        });
+      });
+
       context('factory containing an association', function() {
         it('is able to handle that', function(done) {
           factory.build('person', { age: 30 }, function(err, person) {


### PR DESCRIPTION
Adds an afterBuild option to the factories. Useful for filling up properties that depend on other factories, which can then be persisted in the model when saving.