### PR TITLE
Support for transient attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ var builder = factory.withOptions(options);
 
 Currently the supported options are:
 
-#### `afterBuild: function(instance, options, callback)`
+#### `afterBuild: function(instance, attrs, callback)`
 
 Provides a function that is called after the model is built.
 
-#### `afterCreate: function(instance, options, callback)`
+#### `afterCreate: function(instance, attrs, callback)`
 
 Provides a function that is called after a new model instance is saved.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ factory.define('user', User, {
 });
 ```
 
+Other builder options can be accessed, inside hooks, using `this.options`.
+
 ## Defining Associations
 
 ```javascript

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -548,7 +548,7 @@ describe('factory', function() {
     });
 
     it('promisifies #build', function(done) {
-      promisifiedFactory.build('job').spread(function(job, attrs) {
+      promisifiedFactory.build('job').then(function(job) {
         (job instanceof Job).should.be.true;
         job.title.should.eql('Engineer');
         job.company.should.eql('Foobar Inc.');
@@ -557,7 +557,7 @@ describe('factory', function() {
     });
 
     it('works with chained builders too', function(done) {
-      promisifiedFactory.withOptions({}).build('job').spread(function(job, attrs) {
+      promisifiedFactory.withOptions({}).build('job').then(function(job) {
         (job instanceof Job).should.be.true;
         job.title.should.eql('Engineer');
         job.company.should.eql('Foobar Inc.');

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -548,7 +548,7 @@ describe('factory', function() {
     });
 
     it('promisifies #build', function(done) {
-      promisifiedFactory.build('job').then(function(job) {
+      promisifiedFactory.build('job').spread(function(job, attrs) {
         (job instanceof Job).should.be.true;
         job.title.should.eql('Engineer');
         job.company.should.eql('Foobar Inc.');
@@ -557,7 +557,7 @@ describe('factory', function() {
     });
 
     it('works with chained builders too', function(done) {
-      promisifiedFactory.withOptions({}).build('job').then(function(job) {
+      promisifiedFactory.withOptions({}).build('job').spread(function(job, attrs) {
         (job instanceof Job).should.be.true;
         job.title.should.eql('Engineer');
         job.company.should.eql('Foobar Inc.');


### PR DESCRIPTION
Example `password` is transient attribute which is ignored by sequelize (because there is no column specified) but can be used in `afterBuild` hook, and overridden transparently:
```javascript
factory.define('user', User, {
  login: faker.internet.userName(),
  password: faker.inernet.password()
}, {
  afterBuild: function(instance, attrs, callback) {
    instance.setSecurePassword(attrs.password);
    callback(null, instance, attrs);
  }
});
```

```javascript
factory.create('user', { password: 'AnotherPassword' });
```

Instead of meaningful `Immediate` object, builder is passed as `this` in after hooks. So if user needs builder options he can use `this.options`;