### PR TITLE
Adding an example of afterCreate to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,23 @@ Provides a function that is called after the model is built.
 
 Provides a function that is called after a new model instance is saved.
 
+```javascript
+factory.define('user', User, {
+  foo: 'bar'
+}, {
+  afterCreate: function(instance, options, callback) {
+    generateBazBasedOnID(instance.id, function(error, generatedBaz) {
+      if(error) {
+        callback(error, null);
+      } else {
+        instance.baz = generatedBaz;
+        callback(null, instance);
+      }
+    });
+  }
+});
+```
+
 ## Defining Associations
 
 ```javascript


### PR DESCRIPTION
It took me a little while to figure out how to properly use afterCreate. I eventually looked at the tests for afterCreate (https://github.com/aexmachina/factory-girl/blob/1f084fdbd78f93ef81038b06f9fa47acb65e014b/test/factory-test.js#L258) to figure out how to use it.

This commit show an example of how to implement afterCreate, and is based off the tests and the preceding function signature shown for afterCreate.