### PR TITLE
Separate 'attrs' method to receive generated attrs without building

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,22 @@ factory.define('post', Post, {
 
 ## Using Factories
 
+### Factory#attrs
+
+Generates and returns attrs.
+
+```javascript
+factory.attrs('post', function(err, postAttrs) {
+  // postAttrs is a post attributes
+  console.log(postAttrs);
+  // => {title: 'Hello', authorEmail: 'user1@demo.com'}
+});
+
+factory.attrs('post', {title: 'Foo', content: 'Bar'}, function(err, postAttrs) {
+  // build post attrs and override title and content
+});
+```
+
 ### Factory#build
 
 Creates a new (unsaved) instance.

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -77,6 +77,45 @@ describe('factory', function() {
     });
   });
 
+  describe('#attrs', function() {
+      it('correctly generates attrs', function(done) {
+          factory.attrs('job', function(err, jobAttrs) {
+            jobAttrs.should.eql({
+              title: 'Engineer',
+              company: 'Foobar Inc.',
+              duties: {
+                cleaning: false,
+                writing: true,
+                computing: true
+              }
+            });
+            done();
+          });
+      });
+
+      it('correctly overrides attrs', function(done) {
+          var overrides = { title: 'Developer' };
+
+          factory.attrs('job', overrides, function(err, jobAttrs) {
+            jobAttrs.title.should.eql(overrides.title);
+            jobAttrs.company.should.eql('Foobar Inc.');
+            done();
+          });
+      });
+
+      it('correctly handles nested attributes', function(done) {
+          factory.attrs('company', function(err, companyAttrs) {
+            companyAttrs.employees.should.be.instanceof(Array);
+            companyAttrs.employees.length.should.eql(3);
+
+            companyAttrs.managers.should.be.instanceof(Array);
+            companyAttrs.managers.length.should.eql(2);
+
+            done();
+          });
+      });
+  });
+
   describe('#build', function() {
     it('builds, but does not save the object', function(done) {
       factory.build('job', function(err, job) {


### PR DESCRIPTION
It is handy to use with HTTP requests to API.

```javascript
factory.define('user', {
  name: 'Yevhen'
});

factory.attrs('user', { job: 'Developer' }, function(err, attrs) {
  console.log(attrs); # => { name: 'Yevhen', job: 'Developer' }
  helper.post('/user/create', attrs);
});
```