### PR TITLE
Fixing typo in README example. Initializer should return the attrs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ factory.define('user', User, function (buildOptions) {
     attrs.confirmed = true;
     attrs.confirmedAt = new Date();
   }
+
+  return attrs;
 });
 factory.build('user', function(err, user) {
   console.log(user.attributes);


### PR DESCRIPTION
Noticed this today and had to scratch my head for a minute before realizing the docs were wrong.