### PR TITLE
Fix issue with asyncPopulate

### DIFF
--- a/src/utils/asyncPopulate.js
+++ b/src/utils/asyncPopulate.js
@@ -12,6 +12,8 @@ export default function asyncPopulate(target, source) {
     if (Array.isArray(source[attr])) {
       target[attr] = [];
       promise = asyncPopulate(target[attr], source[attr]);
+    } else if (source[attr] === null) {
+      target[attr] = null;
     } else if (typeof source[attr] === 'object') {
       target[attr] = target[attr] || {};
       promise = asyncPopulate(target[attr], source[attr]);

--- a/test/utils/asyncPopulateSpec.js
+++ b/test/utils/asyncPopulateSpec.js
@@ -3,13 +3,9 @@
 import '../test-helper/testUtils';
 import asyncPopulate from '../../src/utils/asyncPopulate';
 import { expect } from 'chai';
-// import _debug from 'debug';
 import asyncFunction from '../test-helper/asyncFunction';
 
-// const debug = _debug('asyncPopulateSpec');
-
 describe('asyncPopulate', function () {
-
   it('returns a promise', function () {
     const asyncPopulateP = asyncPopulate({}, {});
     expect(asyncPopulateP.then).to.be.a('function');
@@ -29,6 +25,7 @@ describe('asyncPopulate', function () {
   it('populates objects correctly', asyncFunction(async function () {
     const source = {
       num: 1,
+      nullValue: null,
       str: 'hello',
       funcs: {
         sync: () => 'shouldHaveThisValue',
@@ -62,6 +59,7 @@ describe('asyncPopulate', function () {
 
     expect(target).to.be.eql({
       num: 1,
+      nullValue: null,
       str: 'hello',
       funcs: {
         sync: 'shouldHaveThisValue',


### PR DESCRIPTION
The asyncPopulate function considers null values as objects
and tries to iterate over it. This commit fixes the issue.