### PR TITLE
V4 fix bson issue

### DIFF
--- a/src/utils/asyncPopulate.js
+++ b/src/utils/asyncPopulate.js
@@ -14,7 +14,7 @@ export default function asyncPopulate(target, source) {
       promise = asyncPopulate(target[attr], source[attr]);
     } else if (source[attr] === null) {
       target[attr] = null;
-    } else if (typeof source[attr] === 'object') {
+    } else if (typeof source[attr] === 'object' && !source[attr]._bsontype) {
       target[attr] = target[attr] || {};
       promise = asyncPopulate(target[attr], source[attr]);
     } else if (typeof source[attr] === 'function') {

--- a/src/utils/asyncPopulate.js
+++ b/src/utils/asyncPopulate.js
@@ -1,4 +1,4 @@
-
+/* eslint-disable no-underscore-dangle */
 export default function asyncPopulate(target, source) {
   if (typeof target !== 'object') {
     return Promise.reject(new Error('Invalid target passed'));
@@ -26,3 +26,4 @@ export default function asyncPopulate(target, source) {
   });
   return Promise.all(promises);
 }
+/* eslint-enable no-underscore-dangle */

--- a/test/integration/MongooseAdapterSpec.js
+++ b/test/integration/MongooseAdapterSpec.js
@@ -1,5 +1,6 @@
 import '../test-helper/testUtils';
 import MongooseAdapter from '../../src/adapters/MongooseAdapter';
+import { factory } from '../../src/index';
 import mongoose from 'mongoose';
 import { expect } from 'chai';
 
@@ -27,6 +28,19 @@ describe('MongooseAdapterIntegration', function () {
     });
 
     db.once('open', () => {
+      const Email = mongoose.model('Email', new mongoose.Schema({
+        subject: String,
+        thread: { type: mongoose.Schema.Types.ObjectId, ref: 'Thread' },
+      }));
+
+      factory.define('email', Email, {
+        subject: 'ttt',
+        thread: factory.assoc('thread', '_id'),
+      });
+
+      const Thread = mongoose.model('Thread', new mongoose.Schema({}));
+      factory.define('thread', Thread, {});
+
       done();
     });
   });
@@ -72,4 +86,16 @@ describe('MongooseAdapterIntegration', function () {
       .catch(err => done(err))
     ;
   });
+
+  /* eslint-disable no-underscore-dangle */
+  it('allows to pass mongo ObjectId as defalt attibute', function (done) {
+    factory.create('thread')
+      .then(thread => {
+        factory.create('email', { thread: thread._id }).then(email => {
+          expect(email.thread).to.be.equal(thread._id);
+          done();
+        });
+      });
+  });
+  /* eslint-enable no-underscore-dangle */
 });

--- a/test/integration/MongooseAdapterSpec.js
+++ b/test/integration/MongooseAdapterSpec.js
@@ -89,6 +89,8 @@ describe('MongooseAdapterIntegration', function () {
 
   /* eslint-disable no-underscore-dangle */
   it('allows to pass mongo ObjectId as defalt attibute', function (done) {
+    mongoUnavailable ? this.skip() : null;
+
     factory.create('thread')
       .then(thread => {
         factory.create('email', { thread: thread._id }).then(email => {

--- a/test/integration/MongooseAdapterSpec.js
+++ b/test/integration/MongooseAdapterSpec.js
@@ -46,7 +46,7 @@ describe('MongooseAdapterIntegration', function () {
   });
 
   it('builds models and access attributes correctly', function (done) {
-    mongoUnavailable ? this.skip() : null;
+    mongoUnavailable && this.skip();
 
     const kitten = adapter.build(Kitten, { name: 'fluffy' });
     expect(kitten).to.be.instanceof(Kitten);
@@ -61,7 +61,7 @@ describe('MongooseAdapterIntegration', function () {
   });
 
   it('saves models correctly', function (done) {
-    mongoUnavailable ? this.skip() : null;
+    mongoUnavailable && this.skip();
 
     const kitten = adapter.build(Kitten, { name: 'fluffy' });
     adapter.save(kitten, Kitten)
@@ -73,7 +73,7 @@ describe('MongooseAdapterIntegration', function () {
   });
 
   it('destroys models correctly', function (done) {
-    mongoUnavailable ? this.skip() : null;
+    mongoUnavailable && this.skip();
 
     const kitten = adapter.build(Kitten, { name: 'smellyCat' });
     adapter.save(kitten, Kitten)
@@ -88,16 +88,16 @@ describe('MongooseAdapterIntegration', function () {
   });
 
   /* eslint-disable no-underscore-dangle */
-  it('allows to pass mongo ObjectId as defalt attibute', function (done) {
-    mongoUnavailable ? this.skip() : null;
+  it('allows to pass mongo ObjectId as a default attribute', function (done) {
+    mongoUnavailable && this.skip();
 
+    let thread;
     factory.create('thread')
-      .then(thread => {
-        factory.create('email', { thread: thread._id }).then(email => {
-          expect(email.thread).to.be.equal(thread._id);
-          done();
-        });
-      });
+      .then(created => (thread = created))
+      .then(() => factory.create('email', { thread: thread._id }))
+      .then(email => expect(email.thread).to.be.equal(thread._id))
+      .then(() => done())
+      .catch(err => done(err));
   });
   /* eslint-enable no-underscore-dangle */
 });


### PR DESCRIPTION
Fix for #75 

Users may want to pass on mongo Object ids as attributes.
These ObjectIds are BSON objects. asyncPopulate thinks of them
plain son objects and copies them deeply which messes up the ObjectId
