### PR TITLE
Add buildOptions support to buildSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ Be aware that `assoc()` is an async function, so it can't be used with `buildSyn
 
 ```javascript
 var doc = factory.buildSync('post', {title: 'Foo'});
+
+// or with buildOptions
+var doc = factory.buildSync('post', { title: 'Foo' }, { veryLong: true });
 ```
 
 ### Factory#cleanup

--- a/index.js
+++ b/index.js
@@ -331,12 +331,16 @@
         });
       };
 
-      builder.buildSync = function (name, attrs) {
+      builder.buildSync = function (name, attrs, buildOptions) {
         if (!factories[name]) {
           throw new Error("No factory defined for model '" + name + "'");
         }
         var model = factories[name].model;
-        attrs = merge(copy(factories[name].attributes), attrs);
+        var attributes = factories[name].attributes;
+        if (typeof attributes === 'function') {
+          attributes = attributes.call(null, buildOptions || {});
+        }
+        attrs = merge(copy(attributes), attrs);
         var names = keys(attrs);
         for (var i = 0; i < names.length; i++) {
           var key = names[i], fn = attrs[key];

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -616,6 +616,35 @@ describe('factory', function () {
         job.constructor.should.eql(Object);
       });
     });
+
+    it('can be used with buildOptions', function() {
+      var company = 'Bar Inc';
+      var another = new factory.Factory();
+      another.setAdapter(new factory.ObjectAdapter(), 'anotherModel');
+      another.define('anotherModel', null, function(buildOptions) {
+        var attrs = {
+          title: 'Scientist',
+          company: 'Foobar Inc.'
+        }
+
+        if (buildOptions.head) {
+          attrs.title = 'Head Scientist';
+        }
+
+        return attrs;
+      });
+
+      another.build('anotherModel', { company: company }, { head: true }, function (err, job) {
+        job.constructor.should.eql(Object);
+        job.title.should.eql('Head Scientist');
+        job.company.should.eql(company);
+      });
+
+      var obj = another.buildSync('anotherModel', { company: company }, { head: true });
+      obj.constructor.should.eql(Object);
+      obj.title.should.eql('Head Scientist');
+      obj.company.should.eql(company);
+    });
   });
 
   describe('#buildSync', function () {

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -2,6 +2,7 @@
 
 var factory = require('..');
 var should = require('chai').should();
+var promise = require('bluebird');
 var context = describe;
 require('./utils/factories');
 var adapters = require('./utils/adapters');

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -2,7 +2,6 @@
 
 var factory = require('..');
 var should = require('chai').should();
-var promise = require('bluebird');
 var context = describe;
 require('./utils/factories');
 var adapters = require('./utils/adapters');
@@ -617,35 +616,6 @@ describe('factory', function () {
         job.constructor.should.eql(Object);
       });
     });
-
-    it('can be used with buildOptions', function() {
-      var company = 'Bar Inc';
-      var another = new factory.Factory();
-      another.setAdapter(new factory.ObjectAdapter(), 'anotherModel');
-      another.define('anotherModel', null, function(buildOptions) {
-        var attrs = {
-          title: 'Scientist',
-          company: 'Foobar Inc.'
-        }
-
-        if (buildOptions.head) {
-          attrs.title = 'Head Scientist';
-        }
-
-        return attrs;
-      });
-
-      another.build('anotherModel', { company: company }, { head: true }, function (err, job) {
-        job.constructor.should.eql(Object);
-        job.title.should.eql('Head Scientist');
-        job.company.should.eql(company);
-      });
-
-      var obj = another.buildSync('anotherModel', { company: company }, { head: true });
-      obj.constructor.should.eql(Object);
-      obj.title.should.eql('Head Scientist');
-      obj.company.should.eql(company);
-    });
   });
 
   describe('#buildSync', function () {
@@ -665,6 +635,12 @@ describe('factory', function () {
         post.title.should.eql('Bazqux Co.');
         post.should.not.have.property('saveCalled');
       });
+    });
+
+    it('allows the use of buildOptions', function() {
+      var user = factory.buildSync('user', {}, { facebookUser: true });
+      (user instanceof User).should.be.true;
+      user.facebook.id.should.exist;
     });
 
     it('allows synchronous function properties', function () {


### PR DESCRIPTION
Seemed arbitrary that it didn't support it.  Initially was trying to chase down a bug affecting ObjectAdapter and buildOptions from version 3.1 but seems to be fixed in the latest master.