### PR TITLE
Adding remove function to remove defined factory

### DIFF
--- a/src/FactoryGirl.js
+++ b/src/FactoryGirl.js
@@ -39,6 +39,10 @@ export default class FactoryGirl {
     return factory;
   }
 
+  remove(name) {
+    delete this.factories[name];
+  }
+
   extend(parent, name, childInitializer, options = {}) {
     if (this.getFactory(name, false)) {
       throw new Error(`Factory ${name} already defined`);


### PR DESCRIPTION
Sometimes, we want to remove defined factory. In my case, I need it because when I use mocha, it watches my files and re-runs project tests, it will say that the factory is defined. It is defined in the first iteration, unfortunately when the test re-run, it will throw that error. This commit will help me to remove defined factory so it won't throw the said error.