### PR TITLE
Undefined property throws error fix

### DIFF
--- a/src/utils/asyncPopulate.js
+++ b/src/utils/asyncPopulate.js
@@ -12,8 +12,8 @@ export default function asyncPopulate(target, source) {
     if (Array.isArray(source[attr])) {
       target[attr] = [];
       promise = asyncPopulate(target[attr], source[attr]);
-    } else if (source[attr] === null) {
-      target[attr] = null;
+    } else if (source[attr] === null || source[attr] === undefined) {
+      target[attr] = source[attr];
     } else if (isPlainObject(source[attr])) {
       target[attr] = target[attr] || {};
       promise = asyncPopulate(target[attr], source[attr]);

--- a/test/utils/asyncPopulateSpec.js
+++ b/test/utils/asyncPopulateSpec.js
@@ -27,6 +27,7 @@ describe('asyncPopulate', function () {
     const source = {
       num: 1,
       nullValue: null,
+      undefinedValue: undefined,
       str: 'hello',
       date: new Date,
       foo: new Foo,
@@ -63,6 +64,7 @@ describe('asyncPopulate', function () {
     expect(target).to.be.eql({
       num: 1,
       nullValue: null,
+      undefinedValue: undefined,
       str: 'hello',
       date: source.date,
       foo: source.foo,


### PR DESCRIPTION
@aexmachina This PR fixes issue #141 in which unhandled error is thrown when a factory source attribute is passed with `undefined` value