### PR TITLE
Initializer function loosing context issue

### DIFF
--- a/src/FactoryGirl.js
+++ b/src/FactoryGirl.js
@@ -35,7 +35,7 @@ export default class FactoryGirl {
     if (this.getFactory(name, false)) {
       throw new Error(`Factory ${name} already defined`);
     }
-    const factory = this.factories[name] = new Factory(Model, initializer, options);
+    const factory = this.factories[name] = new Factory(Model, typeof(initializer) === "function" ? initializer(options) : initializer, options);
     return factory;
   }
 

--- a/test/integration/indexSpec.js
+++ b/test/integration/indexSpec.js
@@ -60,19 +60,22 @@ describe('indexIntegration', function () {
     it('generates sequences correctly', asyncFunction(async function () {
       const objSeq1 = await Factory.build('ObjSeq');
       const objSeq2 = await Factory.build('ObjSeq');
-
-      const funcSeq1 = await Factory.build('FuncSeq');
-      const funcSeq2 = await Factory.build('FuncSeq');
+      const funcSeq1 = await Factory.build('FuncSeq', {}, { prefix: 'seq' });
+      const funcSeq2 = await Factory.build('FuncSeq', {}, { prefix: 'seq' });
 
       expect(objSeq1.s1).to.be.equal(1);
       expect(objSeq1.s2).to.be.equal(1);
-      expect(objSeq1.s3).to.be.equal(1);
+      expect(objSeq1.s3).to.be.equal('seq-1');
       expect(funcSeq1.s1).to.be.equal(1);
+      expect(funcSeq1.s2).to.be.equal(1);
+      expect(funcSeq1.s3).to.be.equal('seq-1');
 
       expect(objSeq2.s1).to.be.equal(2);
       expect(objSeq2.s2).to.be.equal(2);
-      expect(objSeq2.s3).to.be.equal(2);
+      expect(objSeq2.s3).to.be.equal('seq-2');
       expect(funcSeq2.s1).to.be.equal(2);
+      expect(funcSeq2.s2).to.be.equal(2);
+      expect(funcSeq2.s3).to.be.equal('seq-2');
     }));
   });
 });

--- a/test/test-helper/dummyFactories.js
+++ b/test/test-helper/dummyFactories.js
@@ -39,9 +39,11 @@ Factory.define('User', User, {
 Factory.define('ObjSeq', DummyModel, {
   s1: Factory.seq(),
   s2: Factory.seq('ObjSeq.s2'),
-  s3: Factory.seq(),
+  s3: Factory.seq(n => `seq-${n}`),
 });
 
-Factory.define('FuncSeq', DummyModel, () => ({
-  s1: Factory.seq('FuncSeq.s1'),
+Factory.define('FuncSeq', DummyModel, options => ({
+  s1: Factory.seq(),
+  s2: Factory.seq('FuncSeq.s2'),
+  s3: Factory.seq(n => `${options.prefix}-${n}`),
 }));


### PR DESCRIPTION
@aexmachina during some work with the library I noticed that the sequence function was not increasing when used inside of an initializer function:
```javascript
Factory.define('FucSeq', DummyModel, options => ({
  s1: Factory.seq(),
  s2: Factory.seq('FuncSeq.s2'),
  s3: Factory.seq(n => `${options.prefix}-${n}`)
}));
```
In the code above only `s2` will work because we are passing an ID to the generator, but `s1` and `s3` will fail to increase the sequence correctly, it seems a new Factory instance is created each time (not really sure why).

I found there is a test for this but it was incomplete, it was only covering the case of `s2` (please check `test/test-helper/dummyFactories.js:46`), so I added the missing cases for `s1` and `s3` and attempted to fix the issue, which unfortunately proved to be a difficult task.

In this PR I tried to solve the issue by resolving the initializer function before it looses context of the Factory (in the `define` function of `src/FactoryGirl.js`), but obviously this doesn't fully works since we loose the options object that may be passed in the initializer function.

I thought I could seek your advice on how we could solve this issue in the best way, so I hope the explanation is clear enough :)

Thank you in advance for your time!