### PR TITLE
Move babel-runtime to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     }
   ],
   "dependencies": {
-    "babel-runtime": "^6.11.6",
     "chance": "^1.0.4"
   },
   "devDependencies": {
@@ -51,6 +50,7 @@
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
+    "babel-runtime": "^6.11.6",
     "babelify": "^7.3.0",
     "bluebird": "^2.9.25",
     "bookshelf": "^0.10.0",


### PR DESCRIPTION
`babel-runtime` doesn't appear to be an actual dependency anywhere in the source.  Perhaps it's only used to build in a development environment?

Moving this to `devDependencies` (if it isn't necessary) is helpful because package managers will assume the library depends on it otherwise.