### PR TITLE
inherit buildOptions in extended factories

### DIFF
--- a/src/FactoryGirl.js
+++ b/src/FactoryGirl.js
@@ -45,6 +45,7 @@ export default class FactoryGirl {
     }
     const parentFactory = this.getFactory(parent, true);
     const Model = options.model || parentFactory.Model;
+    const jointOptions = { ...parentFactory.options, ...options };
     let jointInitializer;
 
     function resolveInitializer(initializer, buildOptions) {
@@ -66,7 +67,11 @@ export default class FactoryGirl {
       jointInitializer = Object.assign({}, parentFactory.initializer, childInitializer);
     }
 
-    const factory = this.factories[name] = new Factory(Model, jointInitializer, options);
+    const factory = this.factories[name] = new Factory(
+      Model,
+      jointInitializer,
+      jointOptions
+    );
     return factory;
   }
 

--- a/test/FactoryGirlSpec.js
+++ b/test/FactoryGirlSpec.js
@@ -111,6 +111,20 @@ describe('FactoryGirl', function () {
       expect(nameRepeated).to.throw(Error);
     });
 
+    it('inherits buildOptions', async function() {
+      const spy = sinon.spy();
+      const dummyBuildOptions = { afterBuild: spy };
+      factoryGirl.define('parentWithAfterBuild', Object, {
+        parent: true,
+      }, dummyBuildOptions);
+      factoryGirl.extend('parentWithAfterBuild', 'childWithParentAfterBuild', {
+        child: true,
+        override: 'child',
+      });
+      await factoryGirl.build('childWithParentAfterBuild');
+      expect(spy).to.have.been.calledOnce;
+    });
+
     it('can extend with an initializer function', async function () {
       factoryGirl.define('parentWithObjectInitializer', Object, {
         parent: true,


### PR DESCRIPTION
Probably the solution to: https://github.com/simonexmachina/factory-girl/issues/134

- Given a `parentFactory` defined with `buildOptions` with its respective callbacks.
- Given a `childFactory` that extends that `parentFactory`.
- Whenever a models is built out of the aforementioned `childFactory`, 
- the callbacks defined in the `parentFactory` are not being called.
```
const parentFactory = FactoryGirl.define('parent', Model, initializer, buildOptions);
const childFactory = FactoryGirl.extend('parent', 'child');

// whenever we build a childFactory, i.e.
await FactoryGirl.build('child');
// the `afterBuild`, and `afterCreate` callbacks set in parentFactory are not being called
```

This PR tries to solve this.